### PR TITLE
Functionality Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - Operating System: [e.g. macOs, Linux, etc]
+ - Architecture: [e.g amd64, arm64, etc]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,9 @@ jobs:
   run_tests:
     name: Run Cvecli Linux Tests
     runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Setup Go Environment
         uses: actions/setup-go@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: Cvecli Tests
+
+on: [pull_request, push]
+
+env:
+  GOVERSION: '1.17.6'
+
+jobs:
+  run_tests:
+    name: Run Cvecli Linux Tests
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup Go Environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Build Cvecli
+        run: go build ./cmd/cvecli
+      - name: Run Tests
+        run: go test ./...

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@wizedkyle

--- a/config/config.go
+++ b/config/config.go
@@ -15,15 +15,13 @@ type CredentialFile struct {
 }
 
 var (
-	client                *cveservices_go_sdk.APIClient
-	CveServicesProdUrl    = "https://cveawg.mitre.org/api"
-	CveServicesDevUrl     = "https://cveawg-test.mitre.org/api"
-	credentialFilePath    = ".cvecli/credentials/creds.json"
-	ProductionEnvironment = false
-	repoFilePath          = ".cvecli/repos"
+	client             *cveservices_go_sdk.APIClient
+	CveServicesProdUrl = "https://cveawg.mitre.org/api"
+	CveServicesDevUrl  = "https://cveawg-test.mitre.org/api"
+	credentialFilePath = ".cvecli/credentials/creds.json"
 )
 
-func Path(credentialFile bool, repoPath bool) string {
+func Path(credentialFile bool) string {
 	homeDirectory, err := os.UserHomeDir()
 	if err != nil {
 		logging.ConsoleLogger().Error().Err(err).Msg("unable to retrieve user home directory")
@@ -31,17 +29,6 @@ func Path(credentialFile bool, repoPath bool) string {
 	if credentialFile == true {
 		configFile := filepath.Join(homeDirectory, credentialFilePath)
 		return configFile
-	} else if repoPath == true {
-		configFile := filepath.Join(homeDirectory, repoFilePath)
-		return configFile
 	}
 	return ""
-}
-
-func GetClient() *cveservices_go_sdk.APIClient {
-	return client
-}
-
-func SetClient(newClient *cveservices_go_sdk.APIClient) {
-	client = newClient
 }

--- a/internal/cmd/check_id_quota/check_id_quota.go
+++ b/internal/cmd/check_id_quota/check_id_quota.go
@@ -24,9 +24,9 @@ func NewCmdCheckIdQuota(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			checkIdQuota(client, available, quota, totalReserved)
 		},
 	}
-	cmd.Flags().BoolVar(&available, "available", false, "Returns the available CVE IDs for the CNA.")
-	cmd.Flags().BoolVar(&quota, "quota", false, "Returns the quota of CVE IDs for the CNA.")
-	cmd.Flags().BoolVar(&totalReserved, "totalReserved", false, "Returns the total number of reserved CVE IDs for the CNA.")
+	cmd.Flags().BoolVarP(&available, "available", "a", false, "Returns the available CVE IDs for the CNA.")
+	cmd.Flags().BoolVarP(&quota, "quota", "q", false, "Returns the quota of CVE IDs for the CNA.")
+	cmd.Flags().BoolVarP(&totalReserved, "total-reserved", "t", false, "Returns the total number of reserved CVE IDs for the CNA.")
 	return cmd
 }
 

--- a/internal/cmd/create_user/create_user.go
+++ b/internal/cmd/create_user/create_user.go
@@ -31,17 +31,17 @@ func NewCmdCreateUser(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			createUser(client, firstName, lastName, middleName, roles, suffix, username, output)
 		},
 	}
-	cmd.Flags().StringVar(&firstName, "firstname", "", "Specify the first name of the user.")
-	cmd.Flags().StringVar(&lastName, "lastname", "", "Specify the last name of the user.")
-	cmd.Flags().StringVar(&middleName, "middlename", "", "Specify the middle name of the user (if applicable).")
-	cmd.Flags().StringSliceVar(&roles, "roles", []string{}, "Specify the roles for the user comma separated. "+
+	cmd.Flags().StringVarP(&firstName, "first-name", "f", "", "Specify the first name of the user.")
+	cmd.Flags().StringVarP(&lastName, "last-name", "l", "", "Specify the last name of the user.")
+	cmd.Flags().StringVarP(&middleName, "middle-name", "m", "", "Specify the middle name of the user (if applicable).")
+	cmd.Flags().StringSliceVarP(&roles, "roles", "r", []string{}, "Specify the roles for the user comma separated. "+
 		"Valid roles are: 'ADMIN'. Only add the user as an ADMIN if you want them to have control over the organization.")
-	cmd.Flags().StringVar(&suffix, "suffix", "", "Specify the suffix of the user (if applicable).")
-	cmd.Flags().StringVar(&username, "username", "", "Specify the email address of the user.")
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: "+
+	cmd.Flags().StringVarP(&suffix, "suffix", "s", "", "Specify the suffix of the user (if applicable).")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Specify the email address of the user.")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: "+
 		"uuid, secret")
-	cmd.MarkFlagRequired("firstName")
-	cmd.MarkFlagRequired("lastName")
+	cmd.MarkFlagRequired("first-name")
+	cmd.MarkFlagRequired("last-name")
 	cmd.MarkFlagRequired("username")
 	return cmd
 }

--- a/internal/cmd/get_organization_info/get_organization_info.go
+++ b/internal/cmd/get_organization_info/get_organization_info.go
@@ -20,8 +20,8 @@ func NewCmdGetOrganizationInfo(client *cveservices_go_sdk.APIClient) *cobra.Comm
 			getOrganizationInfo(client, output)
 		},
 	}
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: "+
-		"activeroles, idquota, name, shortname, uuid")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: "+
+		"active-roles, id-quota, name, shortname, uuid")
 	return cmd
 }
 
@@ -34,11 +34,11 @@ func getOrganizationInfo(client *cveservices_go_sdk.APIClient, output string) {
 	if err != nil {
 		cmdutils.OutputError(response, err)
 	} else {
-		if output == "activeroles" {
+		if output == "active-roles" {
 			for _, role := range data.Authority.ActiveRoles {
 				fmt.Println(role)
 			}
-		} else if output == "idquota" {
+		} else if output == "id-quota" {
 			fmt.Println(data.Policies.IdQuota)
 		} else if output == "name" {
 			fmt.Println(data.Name)
@@ -55,8 +55,8 @@ func getOrganizationInfo(client *cveservices_go_sdk.APIClient, output string) {
 func outputValidation(output string) bool {
 	switch output {
 	case
-		"activeroles",
-		"idquota",
+		"active-roles",
+		"id-quota",
 		"name",
 		"shortname",
 		"uuid":

--- a/internal/cmd/get_user/get_user.go
+++ b/internal/cmd/get_user/get_user.go
@@ -24,9 +24,9 @@ func NewCmdGetUser(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			getUser(client, username, output)
 		},
 	}
-	cmd.Flags().StringVar(&username, "username", "", "Specify the username of the user to retrieve.")
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: "+
-		"active, activeroles, name, orguuid, username, uuid")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Specify the username of the user to retrieve.")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: "+
+		"active, active-roles, name, org-uuid, username, uuid")
 	cmd.MarkFlagRequired("username")
 	return cmd
 }
@@ -42,7 +42,7 @@ func getUser(client *cveservices_go_sdk.APIClient, username string, output strin
 	} else {
 		if output == "active" {
 			fmt.Println(data.Active)
-		} else if output == "activerole" {
+		} else if output == "active-role" {
 			for _, role := range data.Authority.ActiveRoles {
 				fmt.Println(role)
 			}
@@ -61,7 +61,7 @@ func getUser(client *cveservices_go_sdk.APIClient, username string, output strin
 				name = name + data.Name.Last
 			}
 			fmt.Println(name)
-		} else if output == "orguuid" {
+		} else if output == "org-uuid" {
 			fmt.Println(data.OrgUUID)
 		} else if output == "username" {
 			fmt.Println(data.Username)

--- a/internal/cmd/list_cve_ids/list_cve_ids.go
+++ b/internal/cmd/list_cve_ids/list_cve_ids.go
@@ -27,10 +27,10 @@ func NewCmdListCveIds(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			listCveIds(client, cveIdYear, output, state)
 		},
 	}
-	cmd.Flags().StringVar(&state, "state", "", "Specify the state of the CVE ID. "+
+	cmd.Flags().StringVarP(&state, "state", "s", "", "Specify the state of the CVE ID. "+
 		"Valid values are: RESERVED, PUBLISHED, REJECTED.")
-	cmd.Flags().Int32Var(&cveIdYear, "cveIdYear", 0, "Specify the year of the CVE ID.")
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: cveid")
+	cmd.Flags().Int32VarP(&cveIdYear, "cve-id-year", "c", 0, "Specify the year of the CVE ID.")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: cve-id")
 	return cmd
 }
 
@@ -51,15 +51,16 @@ func listCveIds(client *cveservices_go_sdk.APIClient, cveIdYear int32, output st
 			options.State = optional.NewString(state)
 		} else {
 			fmt.Println("Please enter a valid CVE ID state. Valid states are: RESERVED, PUBLISHED, REJECTED.")
+			os.Exit(1)
 		}
 	}
 	data, response, err := client.ListCveIds(&options)
 	if err != nil {
 		cmdutils.OutputError(response, err)
 	} else {
-		if output == "cveid" {
-			for _, cveid := range *data.CveIds {
-				fmt.Println(cveid.CveId)
+		if output == "cve-id" {
+			for _, cveId := range *data.CveIds {
+				fmt.Println(cveId.CveId)
 			}
 		} else {
 			fmt.Println(string(cmdutils.OutputJson(data)))
@@ -78,9 +79,9 @@ func listCveIdsPagination(client *cveservices_go_sdk.APIClient, options types.Li
 	if err != nil {
 		cmdutils.OutputError(response, err)
 	} else {
-		if output == "cveid" {
-			for _, cveid := range *data.CveIds {
-				fmt.Println(cveid.CveId)
+		if output == "cve-id" {
+			for _, cveId := range *data.CveIds {
+				fmt.Println(cveId.CveId)
 			}
 		} else {
 			fmt.Println(string(cmdutils.OutputJson(data)))
@@ -104,7 +105,7 @@ func stateValidation(state string) bool {
 func outputValidation(output string) bool {
 	switch output {
 	case
-		"cveid":
+		"cve-id":
 		return true
 	}
 	return false

--- a/internal/cmd/list_users/list_users.go
+++ b/internal/cmd/list_users/list_users.go
@@ -24,8 +24,8 @@ func NewCmdListUsers(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			listUsers(client, output)
 		},
 	}
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: "+
-		"active, activeroles, name, uuid")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: "+
+		"active, active-roles, name, uuid")
 	return cmd
 }
 
@@ -46,7 +46,7 @@ func listUsers(client *cveservices_go_sdk.APIClient, output string) {
 		for _, user := range *data.Users {
 			if outputLower == "active" {
 				fmt.Println(user.Username, user.Active)
-			} else if outputLower == "activeroles" {
+			} else if outputLower == "active-roles" {
 				fmt.Println(user.Username, user.Authority.ActiveRoles)
 			} else if outputLower == "name" {
 				var name string
@@ -86,7 +86,7 @@ func listUsersPagination(client *cveservices_go_sdk.APIClient, options types.Lis
 		for _, user := range *data.Users {
 			if outputLower == "active" {
 				fmt.Println(user.Username, user.Active)
-			} else if outputLower == "activeroles" {
+			} else if outputLower == "active-roles" {
 				fmt.Println(user.Username, user.Authority.ActiveRoles)
 			} else if outputLower == "name" {
 				var name string

--- a/internal/cmd/reserve_cve_id/reserve_cve_id.go
+++ b/internal/cmd/reserve_cve_id/reserve_cve_id.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wizedkyle/cvecli/internal/logging"
 	"github.com/wizedkyle/cveservices-go-sdk"
 	"github.com/wizedkyle/cveservices-go-sdk/types"
+	"time"
 )
 
 func NewCmdReserveCveId(client *cveservices_go_sdk.APIClient) *cobra.Command {
@@ -28,15 +29,13 @@ func NewCmdReserveCveId(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			reserveCveId(client, amount, cveYear, nonSequential, sequential, cveIdOutput)
 		},
 	}
-	cmd.Flags().Int32Var(&amount, "amount", 0, "The number of CVE IDs to reserve.")
-	cmd.Flags().BoolVar(&cveIdOutput, "cveIdOutput", false, "Outputs only the CVE IDs.")
-	cmd.Flags().Int32Var(&cveYear, "cveYear", 0, "The year the CVE IDs will be reserved for.")
-	cmd.Flags().BoolVar(&nonSequential, "nonSequential", false, "If the amount of CVE IDs is greater than 1 "+
+	cmd.Flags().Int32VarP(&amount, "amount", "a", 1, "The number of CVE IDs to reserve.")
+	cmd.Flags().BoolVarP(&cveIdOutput, "cve-id-output", "o", false, "Outputs only the CVE IDs.")
+	cmd.Flags().Int32VarP(&cveYear, "cve-year", "y", 0, "The year the CVE IDs will be reserved for. If this is not set it will default to the current year.")
+	cmd.Flags().BoolVarP(&nonSequential, "non-sequential", "n", false, "If the amount of CVE IDs is greater than 1 "+
 		"the IDs will be assigned non sequentially.")
-	cmd.Flags().BoolVar(&sequential, "sequential", false, "If the amount of CVE IDs is greater than 1 "+
+	cmd.Flags().BoolVarP(&sequential, "sequential", "s", false, "If the amount of CVE IDs is greater than 1 "+
 		"the IDs will be assigned sequentially.")
-	cmd.MarkFlagRequired("amount")
-	cmd.MarkFlagRequired("cveYear")
 	return cmd
 }
 
@@ -50,6 +49,11 @@ func reserveCveId(client *cveservices_go_sdk.APIClient, amount int32, cveYear in
 		} else if sequential == true {
 			options.BatchType = optional.NewString("sequential")
 		}
+	}
+	if cveYear == 0 {
+		fmt.Println(cveYear)
+		cveYear = int32(time.Now().Year())
+		fmt.Println(cveYear)
 	}
 	data, response, err := client.ReserveCveId(amount, cveYear, &options)
 	if err != nil {

--- a/internal/cmd/reserve_cve_id/reserve_cve_id.go
+++ b/internal/cmd/reserve_cve_id/reserve_cve_id.go
@@ -51,9 +51,7 @@ func reserveCveId(client *cveservices_go_sdk.APIClient, amount int32, cveYear in
 		}
 	}
 	if cveYear == 0 {
-		fmt.Println(cveYear)
 		cveYear = int32(time.Now().Year())
-		fmt.Println(cveYear)
 	}
 	data, response, err := client.ReserveCveId(amount, cveYear, &options)
 	if err != nil {

--- a/internal/cmd/reset_secret/reset_secret.go
+++ b/internal/cmd/reset_secret/reset_secret.go
@@ -19,7 +19,7 @@ func NewCmdResetSecret(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			resetSecret(client, username)
 		},
 	}
-	cmd.Flags().StringVar(&username, "username", "", "Specify the username which needs the secret reset.")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Specify the username which needs the secret reset.")
 	cmd.MarkFlagRequired("username")
 	return cmd
 }

--- a/internal/cmd/update_user/update_user.go
+++ b/internal/cmd/update_user/update_user.go
@@ -34,18 +34,18 @@ func NewCmdUpdateUser(client *cveservices_go_sdk.APIClient) *cobra.Command {
 			updateUser(client, active, firstName, lastName, middleName, newUsername, output, username, suffix, roleToAdd, roleToRemove)
 		},
 	}
-	cmd.Flags().BoolVar(&active, "active", true, "Set to false if you want to disable the user.")
-	cmd.Flags().StringVar(&firstName, "firstname", "", "Specify the first name of the user.")
-	cmd.Flags().StringVar(&lastName, "lastname", "", "Specify the last name of the user.")
-	cmd.Flags().StringVar(&middleName, "middlename", "", "Specify the middle name of the user (if applicable).")
-	cmd.Flags().StringVar(&newUsername, "newusername", "", "Specify the new email address of the user.")
-	cmd.Flags().StringVar(&username, "username", "", "Specify the current email address of the user.")
-	cmd.Flags().StringVar(&output, "output", "", "Specify a specific value to output. Accepted values are: "+
+	cmd.Flags().BoolVarP(&active, "enabled", "e", true, "Set to false if you want to disable the user.")
+	cmd.Flags().StringVarP(&firstName, "first-name", "f", "", "Specify the first name of the user.")
+	cmd.Flags().StringVarP(&lastName, "last-name", "l", "", "Specify the last name of the user.")
+	cmd.Flags().StringVarP(&middleName, "middle-name", "m", "", "Specify the middle name of the user (if applicable).")
+	cmd.Flags().StringVarP(&newUsername, "new-username", "n", "", "Specify the new email address of the user.")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Specify the current email address of the user.")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Specify a specific value to output. Accepted values are: "+
 		"all, uuid")
-	cmd.Flags().StringVar(&suffix, "suffix", "", "Specify the suffix of the user (if applicable).")
-	cmd.Flags().StringVar(&roleToAdd, "roleToAdd", "", "Specify the role for the user. "+
+	cmd.Flags().StringVarP(&suffix, "suffix", "s", "", "Specify the suffix of the user (if applicable).")
+	cmd.Flags().StringVarP(&roleToAdd, "role-to-add", "a", "", "Specify the role for the user. "+
 		"Valid roles are: 'ADMIN'. Only add the user as an ADMIN if you want them to have control over the organization.")
-	cmd.Flags().StringVar(&roleToRemove, "roleToRemove", "", "Specify the role to remove from the user. "+
+	cmd.Flags().StringVarP(&roleToRemove, "role-to-remove", "r", "", "Specify the role to remove from the user. "+
 		"Valid roles are: 'ADMIN'.")
 	return cmd
 }

--- a/internal/encryption/encryption_test.go
+++ b/internal/encryption/encryption_test.go
@@ -1,0 +1,12 @@
+package encryption
+
+import "testing"
+
+func TestEncryption(t *testing.T) {
+	secret := "secretstring"
+	encryptedText := EncryptData(secret)
+	decryptedText := DecryptData(encryptedText)
+	if decryptedText != secret {
+		t.Errorf("Encryption and decryption failed, got: %s, expected: %s", decryptedText, secret)
+	}
+}

--- a/internal/factory/http.go
+++ b/internal/factory/http.go
@@ -1,5 +1,0 @@
-package factory
-
-func PrepareRequest() {
-
-}

--- a/scripts/build-debianpackage.sh
+++ b/scripts/build-debianpackage.sh
@@ -34,7 +34,7 @@ Version: $version
 Maintainer: kyle@thepublicclouds.com
 Architecture: $architecture
 Homepage: https://github.com/wizedkyle/cvecli
-Description: A CLI tool that allows CNAs to manage their organisation and submit CVEs
+Description: A CLI tool that allows CNAs to manage their organization and submit CVEs
 EOF
 echo "=> Building debian package"
 dpkg --build "./deb/cvecli_$version-1_$architecture"

--- a/scripts/release-debianpackage.sh
+++ b/scripts/release-debianpackage.sh
@@ -105,7 +105,7 @@ Codename: stable
 Version: $version
 Architectures: $releaseArchitectures
 Components: main
-Description: A CLI tool that allows CNAs to manage their organisation and submit CVEs.
+Description: A CLI tool that allows CNAs to manage their organization and submit CVEs.
 Date: $(date -Ru)
 $(generate_hash "MD5Sum" "md5sum")
 $(generate_hash "SHA1" "sha1sum")


### PR DESCRIPTION
# Description

This PR introduces the following functionality:
- `cvecli reserve-cve-id` will default to the current year if `--cve-year` is not set
- All commands have been updated to support short arguments
- The code base to create the authentication file has been move to the `authentication` package from the `cvecli configure` command
- Added `encryption` package test

A new GitHub action has been added to run tests on pushes and pull requests.

close #7 
close #8 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
