### PR TITLE
Added cvecli get-cve-id command and updated builds to use go 1.17.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  GOVERSION: '1.17.6'
+  GOVERSION: '1.17.7'
 
 jobs:
   build:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Cvecli Tests
 on: [pull_request, push]
 
 env:
-  GOVERSION: '1.17.6'
+  GOVERSION: '1.17.7'
 
 jobs:
   run_tests:

--- a/internal/cmd/get_cve_id/get_cve_id.go
+++ b/internal/cmd/get_cve_id/get_cve_id.go
@@ -1,0 +1,45 @@
+package get_cve_id
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/cvecli/internal/authentication"
+	"github.com/wizedkyle/cvecli/internal/cmdutils"
+	cveservices_go_sdk "github.com/wizedkyle/cveservices-go-sdk"
+	"os"
+	"text/tabwriter"
+)
+
+func NewCmdGetCveId(client *cveservices_go_sdk.APIClient, jsonOutput *bool) *cobra.Command {
+	var (
+		cveId string
+	)
+	cmd := &cobra.Command{
+		Use:   "get-cve-id",
+		Short: "Retrieves a CVE ID record by the ID",
+		Long:  "A CVE ID can be retrieved from a different entity if it is in either a REJECTED or PUBLISHED state.",
+		Run: func(cmd *cobra.Command, args []string) {
+			authentication.ConfirmCredentialsSet(client)
+			getCveId(client, cveId, jsonOutput)
+		},
+	}
+	cmd.Flags().StringVarP(&cveId, "cve-id", "c", "", "Specify the CVE ID to retrieve")
+	cmd.MarkFlagRequired("cve-id")
+	return cmd
+}
+
+func getCveId(client *cveservices_go_sdk.APIClient, cveId string, jsonOutput *bool) {
+	data, response, err := client.GetCveId(cveId)
+	if err != nil {
+		cmdutils.OutputError(response, err)
+	} else {
+		if !*jsonOutput {
+			writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+			fmt.Fprintln(writer, "CVE ID\tCVE YEAR\tSTATE\tOWNING CNA\tRESERVED DATE")
+			fmt.Fprintln(writer, data.CveId+"\t"+data.CveYear+"\t"+data.State+"\t"+data.OwningCNA+"\t"+data.Reserved.String())
+			writer.Flush()
+		} else {
+			fmt.Println(string(cmdutils.OutputJson(data)))
+		}
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	NewCmdCheckIdQuota "github.com/wizedkyle/cvecli/internal/cmd/check_id_quota"
 	configureCmd "github.com/wizedkyle/cvecli/internal/cmd/configure"
 	NewCmdCreateUser "github.com/wizedkyle/cvecli/internal/cmd/create_user"
+	NewCmdGetCveId "github.com/wizedkyle/cvecli/internal/cmd/get_cve_id"
 	NewCmdGetOrganizationInfo "github.com/wizedkyle/cvecli/internal/cmd/get_organization_info"
 	NewCmdGetUser "github.com/wizedkyle/cvecli/internal/cmd/get_user"
 	NewCmdListCveIds "github.com/wizedkyle/cvecli/internal/cmd/list_cve_ids"
@@ -32,6 +33,7 @@ func NewCmdRoot() *cobra.Command {
 	client := authentication.GetCVEServicesSDKConfig()
 	cmd.AddCommand(configureCmd.NewCmdConfigure())
 	cmd.AddCommand(NewCmdCreateUser.NewCmdCreateUser(client, &jsonOutput))
+	cmd.AddCommand(NewCmdGetCveId.NewCmdGetCveId(client, &jsonOutput))
 	cmd.AddCommand(NewCmdGetOrganizationInfo.NewCmdGetOrganizationInfo(client, &jsonOutput))
 	cmd.AddCommand(NewCmdGetUser.NewCmdGetUser(client, &jsonOutput))
 	cmd.AddCommand(NewCmdCheckIdQuota.NewCmdCheckIdQuota(client, &jsonOutput))

--- a/website/docs/cmd/cve-ids/cvecli_get_cve_id.md
+++ b/website/docs/cmd/cve-ids/cvecli_get_cve_id.md
@@ -1,0 +1,21 @@
+# cvecli get-cve-id
+
+Retrieves a CVE ID record by the ID
+
+A CVE ID can be retrieved from a different entity if it is in either a REJECTED or PUBLISHED state
+
+```shell
+cvecli get-cve-id [flags]
+```
+
+## Options
+
+```
+-c, --cve-id - Specify the CVE ID to retrieve
+-h, --help   - help for get-cve-id
+```
+
+## See also
+
+* [cvecli](/cmd/cvecli) - A CLI tool that allows CNAs to manage their organisation and CVEs.
+

--- a/website/docs/cmd/cvecli.md
+++ b/website/docs/cmd/cvecli.md
@@ -26,6 +26,7 @@ A CLI tool that allows CNAs to manage their organisation and CVEs.
 * [cvecli check-id-quota](/cmd/cve-ids/cvecli_check_id_quota/) - Checks the CVE ID quotas for the organization
 * [cvecli configure](/cmd/cvecli_configure) - Sets credentials for `cvecli`
 * [cvecli create-user](/cmd/users/cvecli_create_user) - Creates a new user in the organization
+* [cvecli get-cve-id](/cmd/cve-ids/cvecli_get_cve_id/) - Retrieves a CVE ID record by the ID
 * [cvecli get-organization-info](/cmd/organization/cvecli_get_organization_info) - Retrieves information about the organization the user authenticating is apart of
 * [cvecli get-user](/cmd/users/cvecli_get_user) - Retrieves information about a user in the organization
 * [cvecli list-cve-ids](/cmd/cve-ids/cvecli_list_cve_ids) - Lists all CVE Ids associated to an organization.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - cvecli check-id-quota: cmd/cve-ids/cvecli_check_id_quota.md
   - cvecli configure: cmd/cvecli_configure.md
   - cvecli create-user: cmd/users/cvecli_create_user.md
+  - cvecli get-cve-id: cmd/cve-ids/cvecli_get_cve_id.md
   - cvecli get-organization-info: cmd/organization/cvecli_get_organization_info.md
   - cvecli get-user: cmd/users/cvecli_get_user.md
   - cvecli list-cve-ids: cmd/cve-ids/cvecli_list_cve_ids.md


### PR DESCRIPTION
# Description

This PR introduces the `cvecli get-cve-id` command which lets you retrieve information about a specific CVE ID. Documentation has also been updated to reflect the new command.

Release and Test workflows have had their Go version updated from 1.17.6 to 1.17.7.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
